### PR TITLE
Upgrade Java version to 21 on iteration 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.5.RELEASE</version>
+        <version>3.0.13</version>
     </parent>
     <dependencyManagement>
         <dependencies>
@@ -44,43 +44,39 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-test</artifactId>
         <scope>test</scope>
+        <exclusions>
+            <exclusion>
+                <groupId>com.vaadin.external.google</groupId>
+                <artifactId>android-json</artifactId>
+            </exclusion>
+        </exclusions>
         </dependency>
         <!-- Maven -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.13.3</version>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/junit/junit -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.3</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/javax.persistence/javax.persistence-api -->
         <!-- https://mvnrepository.com/artifact/javax.validation/validation-api -->
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-            <version>2.0.1.Final</version>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
 
     </dependencies>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>21</java.version>
     </properties>
 
     <build>
@@ -92,10 +88,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.14.0</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <release>${java.version}</release>
+                    <compilerArgs>
+                        <arg>-Xlint:unchecked</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/amazonaws/samples/appconfig/movies/MoviesController.java
+++ b/src/main/java/com/amazonaws/samples/appconfig/movies/MoviesController.java
@@ -17,15 +17,13 @@ import org.springframework.core.env.Environment;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import software.amazon.awssdk.services.appconfig.AppConfigClient;
 import software.amazon.awssdk.services.appconfig.model.GetConfigurationResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import javax.validation.Valid;
-
-import static org.springframework.web.bind.annotation.RequestMethod.POST;
+import jakarta.validation.Valid;
 
 @RestController
 public class MoviesController {
@@ -107,7 +105,7 @@ public class MoviesController {
         }
     }
 
-    @RequestMapping(value = "/movies/{movie}/edit", method = POST)
+    @PostMapping("/movies/{movie}/edit")
     public String processUpdateMovie(@Valid Movie movie, BindingResult result, @PathVariable("movieId") int movieId) {
         final AppConfigUtility appConfigUtility = new AppConfigUtility(getOrDefault(this::getClient, this::getDefaultClient),
                 getOrDefault(this::getConfigurationCache, ConfigurationCache::new),

--- a/src/main/java/com/amazonaws/samples/appconfig/utils/Encoder.java
+++ b/src/main/java/com/amazonaws/samples/appconfig/utils/Encoder.java
@@ -1,16 +1,24 @@
 // depreciation example - sun.misc.BASE64Encoder;
 package com.amazonaws.samples.appconfig.utils;
-import sun.misc.BASE64Encoder;
 
+import java.util.Base64;
+import java.util.Calendar;
 import java.util.Date;
 
 
 public class Encoder {
 
-    Date defaultDate = new Date(1999, 0, 1);
+    Date defaultDate;
+    
+    {
+        Calendar cal = Calendar.getInstance();
+        cal.set(1999, Calendar.JANUARY, 1, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        defaultDate = cal.getTime();
+    }
 
     byte[] bytes = new byte[57];
-    String enc1 = new sun.misc.BASE64Encoder().encode(bytes);
+    String enc1 = Base64.getEncoder().encodeToString(bytes);
 
 
 }

--- a/src/main/java/com/amazonaws/samples/appconfig/utils/Math.java
+++ b/src/main/java/com/amazonaws/samples/appconfig/utils/Math.java
@@ -1,27 +1,28 @@
 //example from https://docs.openrewrite.org/running-recipes/popular-recipe-guides/migrate-to-java-17
 package com.amazonaws.samples.appconfig.utils;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 public class Math {
-    Boolean bool = new Boolean(true);
-    Byte b = new Byte("1");
-    Character c = new Character('c');
-    Double d = new Double(1.0);
-    Float f = new Float(1.1f);
-    Long l = new Long(1);
-    Short sh = new Short("12");
+    Boolean bool = Boolean.valueOf(true);
+    Byte b = Byte.valueOf("1");
+    Character c = Character.valueOf('c');
+    Double d = Double.valueOf(1.0);
+    Float f = Float.valueOf(1.1f);
+    Long l = Long.valueOf(1);
+    Short sh = Short.valueOf("12");
     short s3 = 3;
-    Short sh3 = new Short(s3);
-    Integer i = new Integer(1);
+    Short sh3 = Short.valueOf(s3);
+    Integer i = Integer.valueOf(1);
 
     public void divide() {
         BigDecimal bd = BigDecimal.valueOf(10);
         BigDecimal bd2 = BigDecimal.valueOf(2);
-        bd.divide(bd2, BigDecimal.ROUND_DOWN);
-        bd.divide(bd2, 1);
-        bd.divide(bd2, 1, BigDecimal.ROUND_CEILING);
-        bd.divide(bd2, 1, 1);
-        bd.setScale(2, 1);
+        bd.divide(bd2, RoundingMode.DOWN);
+        bd.divide(bd2, RoundingMode.DOWN);
+        bd.divide(bd2, 1, RoundingMode.CEILING);
+        bd.divide(bd2, 1, RoundingMode.DOWN);
+        bd.setScale(2, RoundingMode.DOWN);
     }
 
    }

--- a/src/main/java/com/amazonaws/samples/appconfig/utils/Security.java
+++ b/src/main/java/com/amazonaws/samples/appconfig/utils/Security.java
@@ -1,7 +1,7 @@
 //javax.security.cert to java.security.cert classes migration
 package com.amazonaws.samples.appconfig.utils;
 
-import javax.security.cert.*;
+import java.security.cert.*;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -13,7 +13,8 @@ public class Security {
         X509Certificate cert = null;
         try {
             InputStream inStream = new FileInputStream(certFile);
-            cert = X509Certificate.getInstance(inStream);
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            cert = (X509Certificate) cf.generateCertificate(inStream);
         } catch (CertificateException e) {
             throw new RuntimeException(e);
         } catch (FileNotFoundException e) {

--- a/src/test/java/com/amazonaws/samples/appconfig/movies/MathTest.java
+++ b/src/test/java/com/amazonaws/samples/appconfig/movies/MathTest.java
@@ -1,11 +1,10 @@
 package com.amazonaws.samples.appconfig.movies;
-
-import org.junit.Test;
-
+import java.math.RoundingMode;
+import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
-import com.amazonaws.samples.appconfig.utils.Math;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import com.amazonaws.samples.appconfig.utils.Math;
 
 public class MathTest {
 
@@ -18,21 +17,21 @@ public class MathTest {
         BigDecimal bd = BigDecimal.valueOf(10);
         BigDecimal bd2 = BigDecimal.valueOf(2);
         BigDecimal expectedResult1 = BigDecimal.valueOf(5);
-        assertEquals(expectedResult1, bd.divide(bd2, BigDecimal.ROUND_DOWN));
+        assertEquals(expectedResult1, bd.divide(bd2, RoundingMode.DOWN));
 
         // Test divide(BigDecimal, int)
         BigDecimal expectedResult2 = BigDecimal.valueOf(5.0);
 
         // Test divide(BigDecimal, int, int)
         BigDecimal expectedResult3 = BigDecimal.valueOf(5.0);
-        assertEquals(expectedResult3, bd.divide(bd2, 1, BigDecimal.ROUND_CEILING));
+        assertEquals(expectedResult3, bd.divide(bd2, 1, RoundingMode.CEILING));
 
         BigDecimal expectedResult4 = BigDecimal.valueOf(5.0);
-        assertEquals(expectedResult4, bd.divide(bd2, 1, 1));
+        assertEquals(expectedResult4, bd.divide(bd2, 1, RoundingMode.DOWN));
 
         // Test setScale(int, int)
         BigDecimal expectedResult5 = BigDecimal.valueOf(10);
-        bd.setScale(2, 1);
+        bd.setScale(2, RoundingMode.DOWN);
         assertEquals(expectedResult5, bd);
     }
 }

--- a/src/test/java/com/amazonaws/samples/appconfig/movies/MockTest.java
+++ b/src/test/java/com/amazonaws/samples/appconfig/movies/MockTest.java
@@ -1,15 +1,15 @@
 package com.amazonaws.samples.appconfig.movies;
-import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyInt;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
 
@@ -18,6 +18,7 @@ public class MockTest {
     @Test
     public void testList() {
 
+        @SuppressWarnings("unchecked")
         List<String> mocklist = mock(List.class);
 
         when(mocklist.get(anyInt())).thenReturn("Movies");
@@ -29,6 +30,7 @@ public class MockTest {
 
     @Test
     public void creatingASpyOnArrayList() {
+        @SuppressWarnings("unchecked")
         List<String> listSpy = spy(ArrayList.class);
         listSpy.add("Paid");
         listSpy.add("Movies");
@@ -40,7 +42,8 @@ public class MockTest {
 
     @Test
     public void letsMockListSizeWithMultipleReturnValues() {
-        List list = mock(List.class);
+        @SuppressWarnings("unchecked")
+        List<String> list = mock(List.class);
         Mockito.when(list.size()).thenReturn(10).thenReturn(20);
         assertEquals(10, list.size()); // First Call
         assertEquals(20, list.size()); // Second Call
@@ -49,6 +52,7 @@ public class MockTest {
     @Test
     public void letsMockListGet() {
 
+        @SuppressWarnings("unchecked")
         List<String> list = mock(List.class);
 
         Mockito.when(list.get(0)).thenReturn("PaidMovies");

--- a/src/test/java/com/amazonaws/samples/appconfig/movies/MovieTest.java
+++ b/src/test/java/com/amazonaws/samples/appconfig/movies/MovieTest.java
@@ -1,12 +1,8 @@
 package com.amazonaws.samples.appconfig.movies;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 import com.amazonaws.samples.appconfig.movies.MoviesController;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 public class MovieTest {
 

--- a/src/test/java/com/amazonaws/samples/appconfig/movies/MoviesControllerTest.java
+++ b/src/test/java/com/amazonaws/samples/appconfig/movies/MoviesControllerTest.java
@@ -3,8 +3,9 @@ package com.amazonaws.samples.appconfig.movies;
 import com.amazonaws.samples.appconfig.utils.AppConfigUtility;
 import com.amazonaws.samples.appconfig.cache.ConfigurationCache;
 import com.amazonaws.samples.appconfig.model.ConfigurationKey;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.core.env.Environment;
@@ -14,11 +15,14 @@ import software.amazon.awssdk.services.appconfig.model.GetConfigurationResponse;
 import java.time.Duration;
 import java.util.UUID;
 
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class MoviesControllerTest {
+
+    private AutoCloseable mocks;
 
     @Mock
     private Environment env;
@@ -31,9 +35,9 @@ public class MoviesControllerTest {
 
     private MoviesController moviesController;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        mocks = MockitoAnnotations.openMocks(this);
         moviesController = new MoviesController();
         moviesController.env = env;
     }
@@ -51,7 +55,7 @@ public class MoviesControllerTest {
         GetConfigurationResponse getConfigurationResponse = GetConfigurationResponse.builder().build();
 
         AppConfigUtility appConfigUtility = mock(AppConfigUtility.class);
-        when(appConfigUtility.getConfiguration(any(ConfigurationKey.class))).thenReturn(getConfigurationResponse);
+        when(appConfigUtility.getConfiguration(nullable(ConfigurationKey.class))).thenReturn(getConfigurationResponse);
 
         moviesController.cacheItemTtl = Duration.ofSeconds(60);
         moviesController.client = appConfigClient;
@@ -68,6 +72,11 @@ public class MoviesControllerTest {
         }
         //assertArrayEquals(expectedMovies, movies);
         assertEquals(5, expectedMovies.length);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mocks.close();
     }
 
 }


### PR DESCRIPTION
# Java Version Upgrade Project - Executive Summary  
  
## 🎯 Executive Summary  
  
Successfully completed a comprehensive Java modernization project, upgrading a legacy Spring Boot microservice application from Java 8 to Java 21 with Spring Boot 3.0.13. The automated upgrade process using OpenRewrite and Amazon Q CLI achieved a complete transformation with zero compilation errors, all tests passing, and full application functionality preserved. The project eliminated deprecated APIs, resolved dependency conflicts, and modernized the codebase to leverage Java 21's performance improvements and security enhancements.  
  
## 🔧 Application Changes  
  
• **Java Runtime**: ⬆️ Upgraded from Java 8 → Java 21 (3 major version jump)  
• **Spring Boot Framework**: ⬆️ Migrated from 2.x → 3.0.13 with Jakarta EE transition  
• **Testing Framework**: 🧪 JUnit 4 → JUnit 5 migration with modern annotations  
• **Mockito Library**: 📦 Upgraded from 1.x → 4.11.0 for enhanced mocking capabilities  
• **Maven Compiler**: 🛠️ Updated to 3.14.0 with Java 21 release configuration  
• **Dependency Management**: 🔄 Resolved duplicate JSON libraries and cleaned dependency tree  
  
## 🛠️ Tools Used  
  
• **Java SDK**: ☕ Amazon Corretto 21.0.7 runtime environment  
• **OpenRewrite**: 🔄 Version 6.13.0 for automated code transformation  
  - `com.amazonaws.java.migrate.UpgradeToJava21` recipe  
  - `com.amazonaws.java.spring.boot3.UpgradeSpringBoot_3_0` recipe  
• **Amazon Q CLI**: 🤖 Claude-4-Sonnet model for intelligent code analysis and fixes  
• **Maven Build System**: 📦 3.9.10 for dependency management and packaging  
  
## 💻 Code Changes  
  
• **Security.java**: 🔒 Migrated deprecated `javax.security.cert.*` → `java.security.cert.*`  
  - Replaced `X509Certificate.getInstance()` with modern `CertificateFactory` pattern  
• **Encoder.java**: 📅 Fixed deprecated `Date(int, int, int)` constructor → `Calendar` API  
• **MockTest.java**: ⚠️ Resolved unchecked generic operations with `@SuppressWarnings` annotations  
• **pom.xml**: 📋 Added dependency exclusions and compiler lint configuration  
• **Package Migration**: 🔄 `javax.validation.*` → `jakarta.validation.*` namespace transition  
• **Test Annotations**: 🧪 `@Test` imports updated from JUnit 4 → JUnit 5  
  
## ⏱️ Time Savings Estimate  
  
• **OpenRewrite Automation**: 🚀 47 minutes saved (20m Java upgrade + 27m Spring Boot upgrade)  
• **Manual Remediation**: 🔧 ~2-3 hours for deprecated API fixes and dependency resolution  
• **Testing & Validation**: ✅ ~1 hour for comprehensive verification  
• **Total Project Time**: ⏰ ~4-5 hours vs estimated 12-15 hours manual effort  
• **Efficiency Gain**: 📈 ~70% time reduction through automation  
  
## 🎯 Next Steps  
  
### Immediate Validation  
• ✅ **Production Deployment**: Test in staging environment with full integration suite  
• 🔍 **Performance Monitoring**: Baseline Java 21 performance improvements vs Java 8  
• 🛡️ **Security Scanning**: Validate removal of deprecated security APIs  
  
### Recommended Improvements  
• 🚀 **Virtual Threads**: Evaluate Project Loom integration for improved concurrency  
• 📊 **Observability**: Upgrade to Micrometer 1.10.8+ for enhanced metrics  
• 🔧 **Build Optimization**: Consider GraalVM native compilation for faster startup  
• 📦 **Dependency Updates**: Review AWS SDK 2.14.27 for latest features and security patches  
• 🧪 **Test Coverage**: Expand integration tests for Jakarta EE namespace changes  
